### PR TITLE
Provide placeholder dir for root file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,67 @@
-# Go container
-A sandbox project to implement a simple container from scratch in Go
+# Container From Scratch
+Implementing a simple container from scratch in Go
 
-Guided by Liz Rice’s [GOTO 2018 talk](https://www.youtube.com/watch?v=8fi7uSYlOdc)
 
 ---
 
-## What is the purpose of this?
-To demonstrate the basics of how a container can be constructed inside a host operating system
+## Overview
+This small program demonstrates a simplified version of how a container can be constructed inside a host operating system.
+
+It was guided by Liz Rice’s amazing [GOTO 2018 talk](https://www.youtube.com/watch?v=8fi7uSYlOdc).
 
 
 ## Prerequisites
-* Must be run on a Linux machine
-* Install [Go](https://golang.org/dl/)
-* Ensure you are operating with root privileges on host. Hint: you may need to use `sudo bash`  
+* Linux machine
+* Go installed
+* Operating with root privileges. Hint: you may need to use `sudo bash`
 
 
 ## How to run
 #### 1. Clone repository
 ```
-git clone https://github.com/natasharw/container-from-scratch-golang.git
+$ git clone https://github.com/natasharw/container-from-scratch-golang.git
 ```
-#### 2. Decide what distribution you want for the container, e.g. Ubuntu or Alpine. Download a copy of its root file system into a new directory.
-Example using Ubuntu Minimal:
+#### 2. Extract an image of a root file system for the container into the empty placeholder directory
+Good choices for distribution might be Alpine or Ubuntu. Here is an example using a minimal Ubuntu distribution:
 ```
-mkdir my-new-fs
-```
-```
-cd my-new-fs
+$ cd container-from-scratch-golang/root-file-system
 ```
 ```
-curl -o ubuntu-minimal.tar.gz http://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64-root.tar.xz
+$ curl -o ubuntu-minimal.tar.gz http://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64-root.tar.xz
 ```
 ```
-tar xvf ubuntu-minimal.tar.qz
+$ tar xvf ubuntu-minimal.tar.qz
 ```
 ```
-rm ubuntu-minimal.tar.qz
+$ rm ubuntu-minimal.tar.qz
 ```
-#### 3. Change the path called by Chroot command in `main.go` to your new file system's directory:
-Example: 
-`must(syscall.Chroot("/path/to/your/my-new-fs"))` —> `must(syscall.Chroot(“/home/natasha/my-new-fs”))`
+#### 3. Move back to main directory
+```
+$ cd ..
+```
 #### 4. Run the container, specifying a desired process
 For example, to run a bash session:
 ```
-go run main.go run /bin/bash
+$ go run main.go run /bin/bash
 ```
 #### 5. Success! You are now running a simple container
 
 #### 6. From inside a container bash session, test some commands:
-  - `ps` - check that the process ids are different to those visible on the host
-  - `ls /` - check that the root file system is different to that of the host
-  - `hostname` - check that the hostname is set is different to that of the host
+  - `$ ps` - check that the process ids are different to those visible on the host
+  - `$ ls /` - check that the root file system is different to that of the host
+  - `$ hostname` - check that the hostname is set is different to that of the host
   
-#### 7. Use `exit` to stop running the container
+#### 7. Stop running the container
+```
+$ exit
+```
 
----
 ## What is happening?
 
-* A container with its own namespaces for hostname, process ids and mounts is set up by `syscall.CLONE_NEWUTS`, `syscall.CLONE_NEWPID` and `syscall.CLONE_NEWNS`
+* A container with its own isolated namespaces for hostname, process IDs and mounts are set up by `syscall.CLONE_NEWUTS`, `syscall.CLONE_NEWPID` and `syscall.CLONE_NEWNS`
 * `syscall.Sethostname()` sets a different hostname for the container
-* The container points towards a new root file system (whatever you decided to base it on) through `syscall.Chroot()` and `syscall.Chdir()`
+* The container points towards the new root file system with `syscall.Chroot()` and `syscall.Chdir()`
 * A new `proc/` folder is mounted with `syscall.Mount()`, allowing process IDs to be isolated from those of the host operating system
-  * `ps` command will now only show the container’s processes
-* A control group is set up with the custom function `cg()`
-  * The arbitrary rule set up is to limit the max number of processes that the container can run to 30. This could be used to limit memory or CPU usage instead
+  * `$ ps` will now only show the container’s processes
+* A control group for the container is created with the custom function `cg()`
+  * The arbitrary rule used is to limit the maximum number of processes that the container can run. A control group could be used to limit memory or CPU usage instead if you wanted

--- a/main.go
+++ b/main.go
@@ -27,18 +27,15 @@ func main() {
 func run() {
 	fmt.Printf("Running %v as pid %d\n", os.Args[2:], os.Getpid())
 
-	//take command line arguments as input
-	//creates child process to set specifics of container
 	cmd := exec.Command("/proc/self/exe", append([]string{"child"}, os.Args[2:]...)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	//create new hostname, process ids, and mounts namespaces
-	//CLONE_NEWUTS: new unix time sharing namespace
-	//CLONE_NEWPID: new process ids namespaces
-	//CLONE_NEWNS: new namespace for mounts
-	//Unshareflags: do not share mounts of container back with the host
+	// CLONE_NEWUTS: new unix time sharing namespace (hostname)
+	// CLONE_NEWPID: new processes namespace
+	// CLONE_NEWNS: new mounts namespace
+	// Unshareflags: do not share mounts of container back with the host
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags:   syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
 		Unshareflags: syscall.CLONE_NEWNS,
@@ -54,37 +51,35 @@ func child() {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	//set up a control group to specify what resources the container can use
-	cg()
+	// set up control group against container resources
+	setCg()
 
-	// set a new hostname on creation of container
+	// set hostname for container
 	must(syscall.Sethostname([]byte(hostName)))
 
-	//change container's root directory to be the desired file system
-	must(syscall.Chroot("/path/to/your/my-new-fs"))
+	// change container's root directory
+	must(syscall.Chroot("./root-file-system/"))
 	must(syscall.Chdir("/"))
 
 	// mount proc at proc, declaring it is a proc file system
-	// this allows process ids to be isolated
 	must(syscall.Mount("proc", "proc", "proc", 0, ""))
 
 	must(cmd.Run())
 
-	//clean up mounts
+	// clean up mounts
 	must(syscall.Unmount("/proc", 0))
 }
 
-func cg() {
+func setCg() {
 	cgroups := "/sys/fs/cgroup/"
 	pids := filepath.Join(cgroups, "pids")
 
-	// create new directory for control group
 	os.Mkdir(filepath.Join(pids, "newcg"), 0755)
 
 	// state rule to set max number of system processes within control group
 	must(ioutil.WriteFile(filepath.Join(pids, "newcg/pids.max"), []byte(maxProcesses), 0700))
 
-	// remove this when container exits
+	// remove when container exits
 	must(ioutil.WriteFile(filepath.Join(pids, "newcg/notify_on_release"), []byte("1"), 0700))
 
 	// write current process id into file to identify it belongs to control group

--- a/root-file-system/placeholder.md
+++ b/root-file-system/placeholder.md
@@ -1,0 +1,1 @@
+placeholder directory for the new root file system - see README


### PR DESCRIPTION
## Overview

This small PR adds some relatively superficial changes, which will reduce the steps and complexion involved in cloning and running locally

## Details

* Empty placeholder directory provided for root file system
* `Chroot()` call in `main.go` now points at new directory
* Some tidying, function renaming and update to README